### PR TITLE
fix: set explicit version to resolve dependencies during MFE builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@edx/frontend-platform",
-  "version": "1.0.0-semantically-released",
+  "version": "7.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@edx/frontend-platform",
-      "version": "1.0.0-semantically-released",
+      "version": "7.1.4",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-platform",
-  "version": "1.0.0-semantically-released",
+  "version": "7.1.4",
   "description": "Foundational application framework for Open edX micro-frontend applications.",
   "main": "index.js",
   "publishConfig": {

--- a/src/i18n/lib.js
+++ b/src/i18n/lib.js
@@ -211,6 +211,7 @@ const messagesShape = {
   en: PropTypes.objectOf(PropTypes.string),
   'es-419': PropTypes.objectOf(PropTypes.string), // Spanish, Latin American
   fr: PropTypes.objectOf(PropTypes.string), // French
+  'fr-ca': PropTypes.objectOf(PropTypes.string), // French Canadian
   'zh-cn': PropTypes.objectOf(PropTypes.string), // Chinese, Simplified
   ca: PropTypes.objectOf(PropTypes.string), // Catalan
   he: PropTypes.objectOf(PropTypes.string), // Hebrew

--- a/src/i18n/lib.test.js
+++ b/src/i18n/lib.test.js
@@ -80,10 +80,11 @@ describe('lib', () => {
         messages: {},
       });
 
-      expect(console.warn).toHaveBeenCalledTimes(15);
+      expect(console.warn).toHaveBeenCalledTimes(16);
       expect(console.warn).toHaveBeenCalledWith('Missing locale: ar');
       expect(console.warn).toHaveBeenCalledWith('Missing locale: es-419');
       expect(console.warn).toHaveBeenCalledWith('Missing locale: fr');
+      expect(console.warn).toHaveBeenCalledWith('Missing locale: fr-ca');
       expect(console.warn).toHaveBeenCalledWith('Missing locale: zh-cn');
       expect(console.warn).toHaveBeenCalledWith('Missing locale: ca');
       expect(console.warn).toHaveBeenCalledWith('Missing locale: he');


### PR DESCRIPTION
This resolves dependency conflicts during MFEs build.

```
# used:
npm version 7.1.4 --no-git-tag-version
```