### PR TITLE
fix: [CHTC-51] reconfigure i18n scripts for override from source use …

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "test:watch": "npm run test -- --watch"
   },
   "bin": {
-    "intl-imports.js": "i18n/scripts/intl-imports.js",
-    "transifex-utils.js": "i18n/scripts/transifex-utils.js"
+    "intl-imports.js": "src/i18n/scripts/intl-imports.js",
+    "transifex-utils.js": "src/i18n/scripts/transifex-utils.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I18n scripts become broken due to direct source usage (instead of published package).


```
# error example:

0.793 ./node_modules/.bin/intl-imports.js frontend-platform paragon frontend-component-header frontend-component-footer frontend-app-profile
0.793 make: ./node_modules/.bin/intl-imports.js: No such file or directory
0.793 make: *** [Makefile:42: pull_translations] Error 127
```


  1. In the git repository: The script is located at src/i18n/scripts/intl-imports.js
  2. The package.json bin expects: i18n/scripts/intl-imports.js (without src/)
  3. When published to npm: The build process (Makefile:15) transpiles src/ → dist/, so the file ends up at the correct location
  4. When installing from git (Dockerfile:503): npm tries to create symlinks based on the bin paths, but finds no file at i18n/scripts/intl-imports.js
  because it's actually at src/i18n/scripts/intl-imports.js