### PR TITLE
fix: [CHTC-51] add missing exports for Account MFE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build:
 	@# --copy-files will bring in everything else that wasn't processed by babel. Remove what we don't want.
 	@find dist -name '*.test.js*' -delete
 	rm ./dist/setupTest.js
-	node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('./package.json')); pkg.main='index.js'; pkg.exports={'.':'./index.js','./i18n':'./i18n/index.js','./react':'./react/index.js','./auth':'./auth/index.js','./analytics':'./analytics/index.js','./logging':'./logging/index.js','./testing':'./testing/index.js'}; pkg.bin={'intl-imports.js':'i18n/scripts/intl-imports.js','transifex-utils.js':'i18n/scripts/transifex-utils.js'}; delete pkg.scripts.prepare; fs.writeFileSync('./dist/package.json',JSON.stringify(pkg,null,2));"
+	node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('./package.json')); pkg.main='index.js'; pkg.exports={'.':'./index.js','./analytics':'./analytics/index.js','./auth':'./auth/index.js','./i18n':'./i18n/index.js','./logging':'./logging/index.js','./react':'./react/index.js','./scripts':'./scripts/index.js','./testing':'./testing/index.js','./config':'./config.js','./constants':'./constants.js','./initialize':'./initialize.js','./pubSub':'./pubSub.js','./utils':'./utils.js'}; pkg.bin={'intl-imports.js':'i18n/scripts/intl-imports.js','transifex-utils.js':'i18n/scripts/transifex-utils.js'}; delete pkg.scripts.prepare; fs.writeFileSync('./dist/package.json',JSON.stringify(pkg,null,2));"
 	cp ./LICENSE ./dist/LICENSE
 	cp ./README.md ./dist/README.md
 

--- a/package.json
+++ b/package.json
@@ -5,12 +5,18 @@
   "main": "dist/index.js",
   "exports": {
     ".": "./dist/index.js",
-    "./i18n": "./dist/i18n/index.js",
-    "./react": "./dist/react/index.js",
-    "./auth": "./dist/auth/index.js",
     "./analytics": "./dist/analytics/index.js",
+    "./auth": "./dist/auth/index.js",
+    "./i18n": "./dist/i18n/index.js",
     "./logging": "./dist/logging/index.js",
-    "./testing": "./dist/testing/index.js"
+    "./react": "./dist/react/index.js",
+    "./scripts": "./dist/scripts/index.js",
+    "./testing": "./dist/testing/index.js",
+    "./config": "./dist/config.js",
+    "./constants": "./dist/constants.js",
+    "./initialize": "./dist/initialize.js",
+    "./pubSub": "./dist/pubSub.js",
+    "./utils": "./dist/utils.js"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Adds missing exports from the FP for Account MFE (and possibly, other MFEs).